### PR TITLE
ops(terraform): provide baseline for aws cloud infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,11 @@ __pycache__/
 
 # Environment variables
 .env
+
+
+### Terraform ###
+
+.terraform/
+*.ftstate
+*.tfstate.backup
+*.lock.hcl

--- a/eemployee_storage/backend.tf
+++ b/eemployee_storage/backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "6.2.0"
+    }
+  }
+}

--- a/eemployee_storage/employee-storage.sh
+++ b/eemployee_storage/employee-storage.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Elastic object storage and VPC set up for Employee Data Storage
+
+# Set AWS profile to use LocalStack
+
+export AWS_PROFILE=localstack
+
+# Variables configuration
+
+REGION="us-east-1"
+VPC_NAME="employee-data-vpc"
+BUCKET_NAME="employee-data-storage"
+SUBNET_NAME="employee-data-subnet"
+
+echo "Starting LocalStack AWS infrastructure setup..."
+sudo localstack start -d
+echo "localstack is running"
+
+echo "Region: $REGION"
+echo "VPC Name: $VPC_NAME"
+echo "Bucket Name: $BUCKET_NAME"
+echo "Creating s3 buckets..."
+
+
+# Creating VPC - Got the VPC ID from localstack chatbot
+
+
+echo "Creating VPV..."
+VPC_ID=$(aws ec2 create-vpc \
+--cidr-block 10.0.0.0/16 | jq -r '.Vpc.VpcId')
+
+#Creating internet gateway
+
+echo "Creating Internet Gateway..."
+INTERNET_GW_ID=$(aws ec2 create-internet-gateway | jq -r '.InternetGateway.InternetGatewayId')
+
+#Creating S3 bucket
+echo "Creating S3 bucket..."
+
+echo "S3 bucket created: $BUCKET_NAME"
+
+echo "Creation complete"

--- a/eemployee_storage/main.tf
+++ b/eemployee_storage/main.tf
@@ -1,0 +1,53 @@
+# Main infrastructure resources for LocalStack
+
+resource "aws_s3_bucket" "employee_data_storage" {
+  bucket = "employee-data-storage-2"
+
+  tags = {
+    Name        = "employee-data-storage-2"
+    Environment = "Dev"
+  }
+}
+
+# Create VPC
+resource "aws_vpc" "employee_data_vpc" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = {
+    Name        = "${var.project_name}-vpc"
+    description = "VPC for employee_data_storage"
+  }
+}
+# Create Internet Gateway
+
+resource "aws_internet_gateway" "employee_data_igw" {
+  vpc_id = aws_vpc.employee_data_vpc.id
+
+  tags = {
+    Name = "${var.project_name}-igw"
+  }
+}
+
+# Create S3 bucket
+resource "aws_s3_bucket" "employee_data_bucket" {
+  bucket = var.project_name
+
+  tags = {
+    Name       = "${var.s3_bucket_name}-bucket"
+    Purpose    = "Employee Data Storage"
+    Compliance = "Required"
+  }
+}
+# resource "aws_instance" "dev_server" {
+#   count = 4 # create four similar EC2 instances
+
+#   ami           = var.ami_id_ubuntu_20_04
+#   instance_type = var.low_tier_ec2_instance_type
+
+#   tags = {
+#     Name        = "MyInstance ${count.index}"
+#     Environment = "Dev"
+#   }
+# }

--- a/eemployee_storage/providers.tf
+++ b/eemployee_storage/providers.tf
@@ -1,0 +1,9 @@
+provider "aws" {
+  region                      = "us-east-1"
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_requesting_account_id  = true
+  endpoints {
+    s3 = "http://s3.localhost.localstack.cloud:4566"
+  }
+}

--- a/eemployee_storage/terraform.tfstate
+++ b/eemployee_storage/terraform.tfstate
@@ -1,0 +1,257 @@
+{
+  "version": 4,
+  "terraform_version": "1.12.2",
+  "serial": 10,
+  "lineage": "0f37dd55-688d-5b47-1d0d-74036d1bb6d6",
+  "outputs": {},
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "aws_internet_gateway",
+      "name": "employee_data_igw",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:ec2:us-east-1:000000000000:internet-gateway/igw-82d94041e36dbd788",
+            "id": "igw-82d94041e36dbd788",
+            "owner_id": "000000000000",
+            "region": "us-east-1",
+            "tags": {
+              "Name": "employee-data-storage-igw"
+            },
+            "tags_all": {
+              "Name": "employee-data-storage-igw"
+            },
+            "timeouts": null,
+            "vpc_id": "vpc-f9e68438f27432aca"
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoxMjAwMDAwMDAwMDAwLCJkZWxldGUiOjEyMDAwMDAwMDAwMDAsInVwZGF0ZSI6MTIwMDAwMDAwMDAwMH19",
+          "dependencies": [
+            "aws_vpc.employee_data_vpc"
+          ]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "aws_s3_bucket",
+      "name": "employee_data_bucket",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "acceleration_status": "",
+            "acl": null,
+            "arn": "arn:aws:s3:::employee-data-storage",
+            "bucket": "employee-data-storage",
+            "bucket_domain_name": "employee-data-storage.s3.amazonaws.com",
+            "bucket_prefix": "",
+            "bucket_region": "us-east-1",
+            "bucket_regional_domain_name": "employee-data-storage.s3.us-east-1.amazonaws.com",
+            "cors_rule": [],
+            "force_destroy": false,
+            "grant": [
+              {
+                "id": "75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a",
+                "permissions": [
+                  "FULL_CONTROL"
+                ],
+                "type": "CanonicalUser",
+                "uri": ""
+              }
+            ],
+            "hosted_zone_id": "Z3AQBSTGFYJSTF",
+            "id": "employee-data-storage",
+            "lifecycle_rule": [],
+            "logging": [],
+            "object_lock_configuration": [],
+            "object_lock_enabled": false,
+            "policy": "",
+            "region": "us-east-1",
+            "replication_configuration": [],
+            "request_payer": "BucketOwner",
+            "server_side_encryption_configuration": [
+              {
+                "rule": [
+                  {
+                    "apply_server_side_encryption_by_default": [
+                      {
+                        "kms_master_key_id": "",
+                        "sse_algorithm": "AES256"
+                      }
+                    ],
+                    "bucket_key_enabled": false
+                  }
+                ]
+              }
+            ],
+            "tags": {
+              "Compliance": "Required",
+              "Name": "employee-data-storage-bucket",
+              "Purpose": "Employee Data Storage"
+            },
+            "tags_all": {
+              "Compliance": "Required",
+              "Name": "employee-data-storage-bucket",
+              "Purpose": "Employee Data Storage"
+            },
+            "timeouts": null,
+            "versioning": [
+              {
+                "enabled": false,
+                "mfa_delete": false
+              }
+            ],
+            "website": [],
+            "website_domain": null,
+            "website_endpoint": null
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "identity": {
+            "account_id": "",
+            "bucket": "employee-data-storage",
+            "region": "us-east-1"
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoxMjAwMDAwMDAwMDAwLCJkZWxldGUiOjM2MDAwMDAwMDAwMDAsInJlYWQiOjEyMDAwMDAwMDAwMDAsInVwZGF0ZSI6MTIwMDAwMDAwMDAwMH19"
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "aws_s3_bucket",
+      "name": "employee_data_storage",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "acceleration_status": "",
+            "acl": null,
+            "arn": "arn:aws:s3:::employee-data-storage-2",
+            "bucket": "employee-data-storage-2",
+            "bucket_domain_name": "employee-data-storage-2.s3.amazonaws.com",
+            "bucket_prefix": "",
+            "bucket_region": "us-east-1",
+            "bucket_regional_domain_name": "employee-data-storage-2.s3.us-east-1.amazonaws.com",
+            "cors_rule": [],
+            "force_destroy": false,
+            "grant": [
+              {
+                "id": "75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a",
+                "permissions": [
+                  "FULL_CONTROL"
+                ],
+                "type": "CanonicalUser",
+                "uri": ""
+              }
+            ],
+            "hosted_zone_id": "Z3AQBSTGFYJSTF",
+            "id": "employee-data-storage-2",
+            "lifecycle_rule": [],
+            "logging": [],
+            "object_lock_configuration": [],
+            "object_lock_enabled": false,
+            "policy": "",
+            "region": "us-east-1",
+            "replication_configuration": [],
+            "request_payer": "BucketOwner",
+            "server_side_encryption_configuration": [
+              {
+                "rule": [
+                  {
+                    "apply_server_side_encryption_by_default": [
+                      {
+                        "kms_master_key_id": "",
+                        "sse_algorithm": "AES256"
+                      }
+                    ],
+                    "bucket_key_enabled": false
+                  }
+                ]
+              }
+            ],
+            "tags": {
+              "Environment": "Dev",
+              "Name": "employee-data-storage-2"
+            },
+            "tags_all": {
+              "Environment": "Dev",
+              "Name": "employee-data-storage-2"
+            },
+            "timeouts": null,
+            "versioning": [
+              {
+                "enabled": false,
+                "mfa_delete": false
+              }
+            ],
+            "website": [],
+            "website_domain": null,
+            "website_endpoint": null
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "identity": {
+            "account_id": "",
+            "bucket": "employee-data-storage-2",
+            "region": "us-east-1"
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoxMjAwMDAwMDAwMDAwLCJkZWxldGUiOjM2MDAwMDAwMDAwMDAsInJlYWQiOjEyMDAwMDAwMDAwMDAsInVwZGF0ZSI6MTIwMDAwMDAwMDAwMH19"
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "aws_vpc",
+      "name": "employee_data_vpc",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "arn": "arn:aws:ec2:us-east-1:000000000000:vpc/vpc-f9e68438f27432aca",
+            "assign_generated_ipv6_cidr_block": false,
+            "cidr_block": "10.0.0.0/16",
+            "default_network_acl_id": "acl-b4ae1fdb495f5abe2",
+            "default_route_table_id": "rtb-e8768eebd50ce8884",
+            "default_security_group_id": "sg-d13cdc381d41bff96",
+            "dhcp_options_id": "default",
+            "enable_dns_hostnames": true,
+            "enable_dns_support": true,
+            "enable_network_address_usage_metrics": false,
+            "id": "vpc-f9e68438f27432aca",
+            "instance_tenancy": "default",
+            "ipv4_ipam_pool_id": null,
+            "ipv4_netmask_length": null,
+            "ipv6_association_id": "",
+            "ipv6_cidr_block": "",
+            "ipv6_cidr_block_network_border_group": "",
+            "ipv6_ipam_pool_id": "",
+            "ipv6_netmask_length": 0,
+            "main_route_table_id": "rtb-e8768eebd50ce8884",
+            "owner_id": "000000000000",
+            "region": "us-east-1",
+            "tags": {
+              "Name": "employee-data-storage-vpc",
+              "description": "VPC for employee_data_storage"
+            },
+            "tags_all": {
+              "Name": "employee-data-storage-vpc",
+              "description": "VPC for employee_data_storage"
+            }
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
+        }
+      ]
+    }
+  ],
+  "check_results": null
+}

--- a/eemployee_storage/variables.tf
+++ b/eemployee_storage/variables.tf
@@ -1,0 +1,83 @@
+variable "aws_region" {
+  description = "AWS region for resources"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "localstack_endpoint" {
+  description = "LocalStack endpoint URL"
+  type        = string
+  default     = "http://localhost:4566"
+}
+
+variable "project_name" {
+  description = "Name of the project"
+  type        = string
+  default     = "employee-data-storage"
+}
+
+variable "environment" {
+  description = "Environment name"
+  type        = string
+  default     = "localstack"
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for VPC"
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "s3_bucket_name" {
+  description = "Name of project"
+  type        = string
+  default     = "employee-data-storage"
+}
+
+variable "s3_lifecycle_ia_days" {
+  description = "Number of days after which objects transition to IA storage class"
+  type        = number
+  default     = 30
+}
+
+variable "s3_lifecycle_glacier_days" {
+  description = "Number of days after which objects transition to Glacier storage class"
+  type        = number
+  default     = 90
+}
+variable "low_tier_ec2_instance_type" {
+  description = "EC2 instance type for low tier"
+  type        = string
+  default     = "t2.micro"
+}
+
+variable "mid_tier_ec2_instance_type" {
+  description = "EC2 instance type for mid tier"
+  type        = string
+  default     = "t3.medium"
+}
+
+variable "high_tier_ec2_instance_type" {
+  description = "EC2 instance type for high tier"
+  type        = string
+  default     = "t3.large"
+}
+
+variable "ami_id_ubuntu_20_04" {
+  description = "Ubuntu 20.04 LTS"
+  type        = string
+  default     = "ami-020cba7c55df1f615"
+}
+
+variable "ami_id_windows_2019" {
+  description = "Windows Server 2019"
+  type        = string
+  default     = "ami-0c55b159cbfafe1f0"
+
+}
+
+
+
+
+
+


### PR DESCRIPTION
- **chore: ignore terraform state files and other miscellaneous files**
- **ops(terraform): provide baseline for aws cloud infrastructure**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added infrastructure-as-code templates for employee data storage using Terraform, including S3 buckets, VPC, and Internet Gateway setup.
  * Introduced configurable variables for AWS region, project/environment names, VPC settings, S3 lifecycle policies, and EC2 instance types.
  * Provided a shell script to automate AWS resource setup on LocalStack for local development.

* **Chores**
  * Updated ignore rules to exclude Terraform state and lock files from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->